### PR TITLE
Laneview status fix and lane status fix

### DIFF
--- a/src/app/_components/dashboard/LaneStatusItem.tsx
+++ b/src/app/_components/dashboard/LaneStatusItem.tsx
@@ -23,7 +23,6 @@ export default function LaneStatusItem(props: {
     const maxChars = iconCount >= 3 ? 10 : iconCount === 2 ? 12 : 15;
     const displayName = props.name.length <= maxChars ? props.name : props.name.substr(0, maxChars) + '…';
 
-
     return (
         <Paper key={props.id} variant='outlined'
                sx={{ cursor: 'pointer',
@@ -45,14 +44,15 @@ export default function LaneStatusItem(props: {
                     {/*    maxWidth: 100*/}
                     {/*}}>{props.name}</Typography>*/}
 
-                    <Typography variant="body1"  style={{
-                        fontSize: 12,
-                        whiteSpace: 'nowrap',
-                        maxWidth: 100,
-                        textOverflow: 'ellipsis',
-                        overflow: 'hidden'
-                    }}>{displayName}</Typography>
-                    {/*<Typography variant="body1" style={{fontSize: 12, textWrap: 'nowrap',  }}>{props.name.length <= 15 ? props.name : (props.name.substr(0, 15)) }</Typography>*/}
+                    {/*<Typography variant="body1"  style={{*/}
+                    {/*    fontSize: 12,*/}
+                    {/*    whiteSpace: 'nowrap',*/}
+                    {/*    maxWidth: 100,*/}
+                    {/*    textOverflow: 'ellipsis',*/}
+                    {/*    overflow: 'hidden'*/}
+                    {/*}}>{displayName}</Typography>*/}
+
+                    <Typography variant="body1" style={{fontSize: 12, textWrap: 'nowrap',  }}>{props.name.length <= 15 ? props.name : (props.name.substr(0, 15)) }</Typography>
 
                     {props.isFault &&
                         <Tooltip title={'Fault'} arrow placement="top">

--- a/src/app/_components/lane-view/LaneItem.tsx
+++ b/src/app/_components/lane-view/LaneItem.tsx
@@ -40,7 +40,7 @@ export default function LaneItem(props: {
                 <CircleRoundedIcon fontSize="large"
                     color={(
                         props.status === "Alarm" ? "error"
-                            : props.status === 'Tamper' ? "secondary"
+                            : props.status === 'Tamper' || props.status === 'Tamper Off' ? "secondary"
                                 : props.status ==='Fault - Gamma Low' ? 'info'
                                     : props.status === 'Fault - Gamma High' ? 'info'
                                         : props.status === 'Fault - Neutron Low' ? 'info'

--- a/src/app/_components/lane-view/LaneStatus.tsx
+++ b/src/app/_components/lane-view/LaneStatus.tsx
@@ -21,10 +21,11 @@ export default function LaneStatus(props: LaneStatusProps) {
 
 //todo: add in a historic request so initial lane status is not null
 
-  useEffect(() => {
-    if(lastLaneStatus.status != null)
-      setLaneStatus(lastLaneStatus ?? null);
-  }, [lastLaneStatus]);
+  console.log("lanes", props.dataSourcesByLane);
+  // useEffect(() => {
+  //   if(lastLaneStatus.status != null)
+  //     setLaneStatus(lastLaneStatus ?? null);
+  // }, [lastLaneStatus]);
 
   const addSubscriptionCallbacks = useCallback(() => {
     for (let [laneName, laneDSColl] of props.dataSourcesByLane.entries()) {

--- a/src/app/_components/lane-view/LaneStatus.tsx
+++ b/src/app/_components/lane-view/LaneStatus.tsx
@@ -39,7 +39,7 @@ export default function LaneStatus(props: LaneStatusProps) {
 
       laneDSColl.addSubscribeHandlerToALLDSMatchingName('tamperRT', (message: any) => {
         const state = message.values[0].data.tamperStatus;
-        updateStatus(laneName, (state ? 'Tamper' : 'Clear'));
+        updateStatus(laneName, (state ? 'Tamper' : 'Tamper Off'));
 
       });
 

--- a/src/app/lane-view/page.tsx
+++ b/src/app/lane-view/page.tsx
@@ -70,22 +70,20 @@ export default function LaneViewPage() {
         const laneDSMap = new Map<string, LaneDSColl>();
 
         const updatedVideo: typeof SweApi[] = [];
+
         for (let [laneid, lane] of laneMapRef.current.entries()) {
 
             if(laneid === currentLane){
 
-                const laneDSColl = new LaneDSColl();
-                laneDSMap.set(laneid, laneDSColl);
+                console.log(currentLane)
 
+                laneDSMap.set(laneid,new LaneDSColl());
 
-                lane.datastreams.forEach((ds, idx) => {
-
-                    const rtDS = lane.datasourcesRealtime[idx];
-
-                    rtDS.properties.startTime = new Date().toISOString();
-                    rtDS.properties.endTime = "2055-01-01T08:13:25.845Z"
-
+                for( let ds of lane.datastreams){
+                    let idx: number = lane.datastreams.indexOf(ds);
+                    let rtDS = lane.datasourcesRealtime[idx];
                     let laneDSColl = laneDSMap.get(laneid);
+
 
                     if(isGammaDatastream(ds)){
                         laneDSColl.addDS('gammaRT', rtDS);
@@ -111,13 +109,48 @@ export default function LaneViewPage() {
 
                     }
 
-                });
+                }
+                //
+                // lane.datastreams.forEach((ds, idx) => {
+                //
+                //     const rtDS = lane.datasourcesRealtime[idx];
+                //
+                //     rtDS.properties.startTime = new Date().toISOString();
+                //     rtDS.properties.endTime = "2055-01-01T08:13:25.845Z"
+                //
+                //     let laneDSColl = laneDSMap.get(laneid);
+                //
+                //     if(isGammaDatastream(ds)){
+                //         laneDSColl.addDS('gammaRT', rtDS);
+                //         setGammaDS(rtDS)
+                //     }
+                //     if(isNeutronDatastream(ds)){
+                //         laneDSColl.addDS('neutronRT', rtDS);
+                //         setNeutronDS(rtDS);
+                //     }
+                //     if(isTamperDatastream(ds)){
+                //         laneDSColl.addDS('tamperRT', rtDS);
+                //         setTamperDS(rtDS)
+                //
+                //     }
+                //     if(isThresholdDatastream(ds)){
+                //         laneDSColl?.addDS('gammaTrshldRT', rtDS);
+                //         setThresholdDS(rtDS);
+                //     }
+                //
+                //     if(isVideoDatastream(ds)) {
+                //         laneDSColl?.addDS('videoRT', rtDS);
+                //         updatedVideo.push(rtDS)
+                //
+                //     }
+                // });
             }
 
             setVideoDS(updatedVideo);
             setDataSourcesByLane(laneDSMap);
+            console.log("laneds map", laneDSMap)
         }
-    }, [laneMapRef.current]);
+    }, [laneMapRef.current, currentLane]);
 
 
     useEffect(() => {


### PR DESCRIPTION
updated the lane status on dashboard to take in account all lane systems that are started and have a database. the lane status icon is still dependent on the rpm status attached to the parent system